### PR TITLE
Belongs to many

### DIFF
--- a/examples/belogs_to_many.json
+++ b/examples/belogs_to_many.json
@@ -1,0 +1,68 @@
+{
+  "resources": [
+    {
+      "Item": {
+        "timestamps": true,
+        "fields": {
+          "id": {
+            "type": "id",
+            "methods": [
+              "sortable"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "name": "Name"
+          },
+          "properties": {
+            "type": "BelongsToMany",
+            "relation": {
+              "table": "properties",
+              "foreign_key": "item_id"
+            }
+          }
+        }
+      },
+      "Property": {
+        "fields": {
+          "id": {
+            "type": "id"
+          },
+          "title": {
+            "type": "string",
+            "name": "Name"
+          },
+          "items": {
+            "type": "BelongsToMany",
+            "relation": {
+              "table": "items",
+              "foreign_key": "property_id"
+            }
+          }
+        }
+      },
+      "ItemPropertyPivot": {
+        "withResource": false,
+        "withModel": false,
+        "table": "item_property",
+        "fields": {
+          "id": {
+            "type": "id"
+          },
+          "item_id": {
+            "type": "BelongsTo",
+            "relation": {
+              "table": "items"
+            }
+          },
+          "property_id": {
+            "type": "BelongsTo",
+            "relation": {
+              "table": "properties"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/Services/Builders/MigrationBuilder.php
+++ b/src/Services/Builders/MigrationBuilder.php
@@ -46,6 +46,7 @@ class MigrationBuilder extends AbstractBuilder implements EditActionBuilderContr
             if(
                 $column->type() === SqlTypeMap::HAS_ONE
                 || $column->type() === SqlTypeMap::HAS_MANY
+                || $column->type() === SqlTypeMap::BELONGS_TO_MANY
             ) {
                 continue;
             }

--- a/src/Services/Builders/ModelBuilder.php
+++ b/src/Services/Builders/ModelBuilder.php
@@ -40,11 +40,15 @@ class ModelBuilder extends BaseModelBuilder
                 );
             }
 
-            $relation = $column->relation()->table()->str();
+            if($column->dataValue('relation_name')) {
+                $relation = $column->dataValue('relation_name');
+            } else {
+                $relation = $column->relation()->table()->str();
 
-            $relation = ($column->type() === SqlTypeMap::HAS_MANY || $column->type() === SqlTypeMap::BELONGS_TO_MANY)
-                ? $relation->plural()->camel()->value()
-                : $relation->singular()->camel()->value();
+                $relation = ($column->type() === SqlTypeMap::HAS_MANY || $column->type() === SqlTypeMap::BELONGS_TO_MANY)
+                    ? $relation->plural()->camel()->value()
+                    : $relation->singular()->camel()->value();
+            }
 
             $relationColumn = ($column->type() === SqlTypeMap::HAS_MANY || $column->type() === SqlTypeMap::HAS_ONE)
                 ? $column->relation()->foreignColumn()
@@ -52,7 +56,7 @@ class ModelBuilder extends BaseModelBuilder
 
             $relationModel = ! empty($column->dataValue('model_class'))
                 ? $column->dataValue('model_class')
-                : $column->relation()->table()->ucFirstSingular();
+                : $column->relation()->table()->str()->camel()->singular()->ucfirst()->value();
 
             $result = $result->newLine()->newLine()->append(
                 $stubBuilder->getFromStub([

--- a/src/Services/Builders/ResourceBuilder.php
+++ b/src/Services/Builders/ResourceBuilder.php
@@ -107,8 +107,7 @@ class ResourceBuilder extends AbstractBuilder implements EditActionBuilderContra
                 $resourceName = str($column->relation()->table()->camel())->singular()->ucfirst()->value();
 
                 $relationMethod = $column->relation()->table();
-                $relationMethod = ($column->type() === SqlTypeMap::BELONGS_TO
-                || $column->type() === SqlTypeMap::BELONGS_TO_MANY)
+                $relationMethod = $column->type() === SqlTypeMap::BELONGS_TO
                     ? $relationMethod->singular()
                     : $relationMethod->plural();
 

--- a/src/Structures/CodeStructureList.php
+++ b/src/Structures/CodeStructureList.php
@@ -13,45 +13,9 @@ final class CodeStructureList
      */
     private array $codeStructures = [];
 
-    private bool $withModel = true;
-
-    private bool $withMigration = true;
-
-    private bool $withResource = true;
-
     public function addCodeStructure(CodeStructure $codeStructure): void
     {
         $this->codeStructures[] = $codeStructure;
-    }
-
-    public function setWithModel(bool $withModel): void
-    {
-        $this->withModel = $withModel;
-    }
-
-    public function setWithMigration(bool $withMigration): void
-    {
-        $this->withMigration = $withMigration;
-    }
-
-    public function setWithResource(bool $withResource): void
-    {
-        $this->withResource = $withResource;
-    }
-
-    public function withModel(): bool
-    {
-        return $this->withModel;
-    }
-
-    public function withMigration(): bool
-    {
-        return $this->withMigration;
-    }
-
-    public function withResource(): bool
-    {
-        return $this->withResource;
     }
 
     /**

--- a/src/Structures/Factories/StructureFromJson.php
+++ b/src/Structures/Factories/StructureFromJson.php
@@ -38,21 +38,24 @@ final class StructureFromJson implements MakeStructureContract
 
         $codeStructures = new CodeStructureList();
 
-        if(isset($file['withModel'])) {
-            $codeStructures->setWithModel($file['withModel']);
-        }
-
-        if(isset($file['withMigration'])) {
-            $codeStructures->setWithMigration($file['withMigration']);
-        }
-
-        if(isset($file['withResource'])) {
-            $codeStructures->setWithResource($file['withResource']);
-        }
-
         foreach ($file['resources'] as $resource) {
             foreach ($resource as $name => $values) {
-                $codeStructure = new CodeStructure(str($name)->snake()->lower()->plural()->value(), $name);
+
+                $table = $values['table'] ?? str($name)->snake()->lower()->plural()->value();
+
+                $codeStructure = new CodeStructure($table, $name);
+
+                if(isset($values['withModel'])) {
+                    $codeStructure->setDataValue('withModel', $values['withModel']);
+                }
+
+                if(isset($values['withMigration'])) {
+                    $codeStructure->setDataValue('withMigration', $values['withMigration']);
+                }
+
+                if(isset($values['withResource'])) {
+                    $codeStructure->setDataValue('withResource', $values['withResource']);
+                }
 
                 $codeStructure->setDataValue('column', $values['column'] ?? null);
 
@@ -81,6 +84,10 @@ final class StructureFromJson implements MakeStructureContract
                             $field['relation']['foreign_key'],
                             $field['relation']['table'],
                         ));
+
+                        if(! empty($field['relation']['relation_name'])) {
+                            $columnStructure->setDataValue('relation_name', $field['relation']['relation_name']);
+                        }
                     }
 
                     if(isset($field['default'])) {


### PR DESCRIPTION
- Added support for BelongsToMany
```php
Block::make([
    ID::make('id')
        ->sortable(),
    Text::make('Name', 'title'),
    BelongsToMany::make('Properties', 'properties', resource: new PropertyResource()),
]),
```
- Options `withModel`, `withMigration`, `withResource` now refer to the entity and not to the entire structure