### PR TITLE
New command to generate JSON project schema from the entire database

### DIFF
--- a/json_schema.json
+++ b/json_schema.json
@@ -131,6 +131,7 @@
                     {"const": "char"},
                     {"const": "json"},
                     {"const": "jsonb"},
+                    {"const": "text"},
                     {"const": "longText"},
                     {"const": "mediumText"},
                     {"const": "tinyText"},

--- a/src/Commands/MoonShineProjectSchemaCommand.php
+++ b/src/Commands/MoonShineProjectSchemaCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DevLnk\MoonShineBuilder\Commands;
+
+use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Factories\CodeStructureFromMysql;
+use DevLnk\MoonShineBuilder\Structures\CodeStructureList;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Schema;
+use function Laravel\Prompts\multiselect;
+
+class MoonShineProjectSchemaCommand extends Command
+{
+    protected $signature = 'moonshine:project-schema';
+
+    protected array $systemTables = [
+        'cache',
+        'cache_locks',
+        'failed_jobs',
+        'jobs',
+        'job_batches',
+        'migrations',
+        'moonshine_socialites',
+        'moonshine_users',
+        'moonshine_user_roles',
+        'notifications',
+        'password_reset_tokens',
+        'sessions',
+        'telescope_entries',
+        'telescope_entries_tags',
+        'telescope_monitoring',
+    ];
+
+    public function handle(): int
+    {
+        $tablesList = collect(Schema::getTables())
+            ->filter(fn ($v) => ! in_array($v['name'], $this->systemTables))
+            ->mapWithKeys(fn ($v) => [$v['name'] => $v['name']]);
+
+        $pivotTables = multiselect(
+            'Select the pivot table to correctly generate BelongsToMany (Press enter to skip)',
+            $tablesList,
+            []
+        );
+
+        $this->systemTables = array_merge($this->systemTables, $pivotTables);
+        $tablesList = collect(Schema::getTables())
+            ->filter(fn ($v) => ! in_array($v['name'], $this->systemTables))
+            ->mapWithKeys(fn ($v) => [$v['name'] => $v['name']]);
+
+        $tables = multiselect(
+            'Select tables',
+            $tablesList,
+            $tablesList
+        );
+
+        $codeStructures = new CodeStructureList();
+        $tables = array_merge($tables, $pivotTables);
+
+        foreach ($tables as $table) {
+            $entity = str($table)->singular()->camel()->ucfirst()->value();
+
+            $codeStructures->addCodeStructure(CodeStructureFromMysql::make(
+                table: (string) $table,
+                entity: $entity,
+                isBelongsTo: true,
+                hasMany: [],
+                hasOne: [],
+                belongsToMany: []
+            ));
+        }
+
+        $dir = config('moonshine_builder.builds_dir');
+
+        $fileName = "project_" . date('YmdHis') . ".json";
+
+        (new Filesystem())->put("$dir/$fileName", $codeStructures->toJson($pivotTables));
+
+        $this->warn("$fileName was created successfully! To generate resources, run: ");
+        $this->info("php artisan moonshine:build $fileName");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Providers/MoonShineBuilderProvider.php
+++ b/src/Providers/MoonShineBuilderProvider.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace DevLnk\MoonShineBuilder\Providers;
 
 use DevLnk\MoonShineBuilder\Commands\MoonShineBuildCommand;
+use DevLnk\MoonShineBuilder\Commands\MoonShineProjectSchemaCommand;
 use Illuminate\Support\ServiceProvider;
 
 class MoonShineBuilderProvider extends ServiceProvider
 {
     protected array $commands = [
         MoonShineBuildCommand::class,
+        MoonShineProjectSchemaCommand::class,
     ];
 
     public function boot(): void

--- a/src/Services/Builders/ResourceBuilder.php
+++ b/src/Services/Builders/ResourceBuilder.php
@@ -25,6 +25,10 @@ class ResourceBuilder extends AbstractBuilder implements EditActionBuilderContra
         $resourcePath = $this->codePath->path(MoonShineBuildType::RESOURCE->value);
         $modelPath = $this->codePath->path(MoonShineBuildType::MODEL->value);
 
+        $modelUse = class_exists($modelPath->namespace() . '\\' . $modelPath->rawName())
+            ? "\nuse {$modelPath->namespace()}\\{$modelPath->rawName()};"
+            : "";
+
         StubBuilder::make($this->stubFile)
             ->setKey(
                 '{column}',
@@ -36,9 +40,10 @@ class ResourceBuilder extends AbstractBuilder implements EditActionBuilderContra
                 ->value(),
                 ! is_null($this->codeStructure->dataValue('column'))
             )
+            ->setKey('{model_use}', $modelUse, ! empty($modelUse))
+            ->setKey('{todo_model_not_found}', "// TODO model not found\n\t", empty($modelUse))
             ->makeFromStub($resourcePath->file(), [
                 '{namespace}' => $resourcePath->namespace(),
-                '{model_namespace}' => $modelPath->namespace() . '\\' . $modelPath->rawName(),
                 '{field_uses}' => $this->usesFieldsToResource(),
                 '{class}' => $resourcePath->rawName(),
                 '{model}' => $modelPath->rawName(),

--- a/src/Structures/CodeStructureList.php
+++ b/src/Structures/CodeStructureList.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace DevLnk\MoonShineBuilder\Structures;
 
+use DevLnk\LaravelCodeBuilder\Enums\SqlTypeMap;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
+use DevLnk\LaravelCodeBuilder\Services\CodeStructure\ColumnStructure;
+use DevLnk\LaravelCodeBuilder\Services\CodeStructure\RelationStructure;
 
 final class CodeStructureList
 {
@@ -24,5 +27,99 @@ final class CodeStructureList
     public function codeStructures(): array
     {
         return $this->codeStructures;
+    }
+
+    public function toJson(array $pivotTables = []): string
+    {
+        $resources = [];
+
+        if(! empty($pivotTables)) {
+            foreach ($this->codeStructures as $codeStructure) {
+                if(! in_array($codeStructure->table(), $pivotTables)) {
+                    continue;
+                }
+
+                $pivotColumns = [];
+                foreach ($codeStructure->columns() as $column) {
+                    if($column->type() !== SqlTypeMap::BELONGS_TO) {
+                        continue;
+                    }
+                    $pivotColumns[] = [
+                        str($column->relation()->table()->camel())->singular()->value(), // entity name
+                        $column->relation()->table()->raw(), // table name
+                    ];
+                }
+
+                if(count($pivotColumns) !== 2) {
+                    continue;
+                }
+
+                /**
+                 * Result for example:
+                 * <code>
+                 * [
+                 *  'item'     => ['table' => 'properties'],
+                 *  'property' => ['table' => 'items']
+                 * ]
+                 * </code>
+                 */
+                $pivotColumnsResult = [];
+                $pivotColumnsResult[$pivotColumns[0][0]] = [
+                    'table' => $pivotColumns[1][1],
+                ];
+                $pivotColumnsResult[$pivotColumns[1][0]] = [
+                    'table' => $pivotColumns[0][1],
+                ];
+
+                foreach ($this->codeStructures as $findCodeStructure) {
+                    if(! isset($pivotColumnsResult[$findCodeStructure->entity()->raw()])) {
+                        continue;
+                    }
+
+                    $relationColumn = $pivotColumnsResult[$findCodeStructure->entity()->raw()]['table'];
+
+                    $field = new ColumnStructure(
+                        column: $relationColumn,
+                        name: '',
+                        type: SqlTypeMap::BELONGS_TO_MANY,
+                        default: null,
+                        nullable: true
+                    );
+                    $field->setRelation(new RelationStructure('id', $relationColumn));
+
+                    $findCodeStructure->addColumn($field);
+                }
+            }
+        }
+
+        foreach ($this->codeStructures as $codeStructure) {
+            $fields = [];
+            foreach ($codeStructure->columns() as $column) {
+                $field =  [
+                    'column' => $column->column(),
+                    'type' => $column->type()->value,
+                    'default' => $column->default(),
+                    'name' => $column->name()
+                ];
+
+                if($column->relation()) {
+                    $field['relation']['table'] = $column->relation()->table()->raw();
+                    $field['relation']['foreign_column'] = $column->relation()->foreignColumn();
+                }
+
+                $fields[] = $field;
+            }
+
+            $resources[] = [
+                'name' => $codeStructure->entity()->ucFirst(),
+                'timestamps' => $codeStructure->isTimestamps(),
+                'soft_deletes' => $codeStructure->isSoftDeletes(),
+                'withModel' => false,
+                'withMigration' => false,
+                'fields' => $fields
+            ];
+        }
+
+        return json_encode(['resources' => $resources]);
     }
 }

--- a/src/Structures/CodeStructureList.php
+++ b/src/Structures/CodeStructureList.php
@@ -107,6 +107,13 @@ final class CodeStructureList
                     $field['relation']['foreign_column'] = $column->relation()->foreignColumn();
                 }
 
+                if(
+                    $column->column() === 'moonshine_user_id'
+                    && $column->type() === SqlTypeMap::BELONGS_TO
+                ) {
+                    $field['resource_class'] = "\\MoonShine\\Resources\\MoonShineUserResource";
+                }
+
                 $fields[] = $field;
             }
 

--- a/stubs/ModelResourceDefault.stub
+++ b/stubs/ModelResourceDefault.stub
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace {namespace};
 
-use Illuminate\Database\Eloquent\Model;
-use {model_namespace};
+use Illuminate\Database\Eloquent\Model;{model_use}
 
 use MoonShine\Resources\ModelResource;
 use MoonShine\Decorations\Block;
 {field_uses}
-
 /**
  * @extends ModelResource<{model}>
  */
 class {class} extends ModelResource
 {
-    protected string $model = {model}::class;
+    {todo_model_not_found}protected string $model = {model}::class;
 
     protected string $title = '{class}';{column}
 
     public function fields(): array
     {
+        // TODO correct labels values
         return [
             Block::make([{fields}
             ]),
@@ -30,6 +29,7 @@ class {class} extends ModelResource
 
     public function rules(Model $item): array
     {
+        // TODO change it to your own rules
         return [{rules}
         ];
     }

--- a/tests/Feature/ProjectBuildTest.php
+++ b/tests/Feature/ProjectBuildTest.php
@@ -172,7 +172,6 @@ class ProjectBuildTest extends TestCase
 
         $resource = $this->filesystem->get($resourcePath);
         $resourceStringContains = [
-            "use App\Models\Comment;",
             "use MoonShine\Fields\ID;",
             "use MoonShine\Fields\Text;",
             "use MoonShine\Fields\Relationships\BelongsTo;",


### PR DESCRIPTION
- The command builds a json project schema based on the entire database
- Recommended to use if you already have migrations and models
```shell
php artisan moonshine:project-schema

 ┌ Select the pivot table to correctly generate BelongsToMany (Press enter to skip) ┐
 │ item_property                                                                    │
 └──────────────────────────────────────────────────────────────────────────────────┘

 ┌ Select tables ───────────────────────────────────────────────┐
 │ categories                                                   │
 │ comments                                                     │
 │ items                                                        │
 │ products                                                     │
 │ properties                                                   │
 │ users                                                        │
 └──────────────────────────────────────────────────────────────┘

project_20240613113014.json was created successfully! To generate resources, run: 
php artisan moonshine:build project_20240613113014.json

```